### PR TITLE
方案名前缀改为后缀

### DIFF
--- a/moran_aux.schema.yaml
+++ b/moran_aux.schema.yaml
@@ -1,6 +1,6 @@
 schema:
   schema_id: moran_aux
-  name: 魔然·輔篩
+  name: 輔篩·魔然
   version: "20251002"
   author:
     - 自然碼發明人：周志農

--- a/moran_fixed.schema.yaml
+++ b/moran_fixed.schema.yaml
@@ -1,6 +1,6 @@
 schema:
   schema_id: moran_fixed
-  name: 魔然·字詞
+  name: 字詞·魔然
   version: "20241011"
   author:
     - 自然碼發明人：周志農

--- a/moran_sentence.schema.yaml
+++ b/moran_sentence.schema.yaml
@@ -1,6 +1,6 @@
 schema:
   schema_id: moran_sentence
-  name: 魔然·整句
+  name: 整句·魔然
   version: "20250418"
   author:
     - 自然碼發明人：周志農


### PR DESCRIPTION
各个平台的 Rime 输入法，大多会将方案名的第一个字显示在托盘区等地方作为提
示。当前所有方案名都使用“魔然”作为前缀，无法快速判断正在使用的方案。