### PR TITLE
构建时保留 .gitignore 文件

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ clean:
 
 dist: quick
 	mkdir -p $(DESTDIR)
+	cp -a .gitignore $(DESTDIR)
 	cp -a README*.md LICENSE etc $(DESTDIR)
 	cp -a moran* $(DESTDIR)
 	cp -a default.yaml key_bindings.yaml punctuation.yaml symbols.yaml $(DESTDIR)


### PR DESCRIPTION
方便直接通过 git 跟踪 trad 或 simp 分支的用户。