### PR TITLE
Revert "构建时保留 .gitignore 文件 (#169)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ clean:
 
 dist: quick
 	mkdir -p $(DESTDIR)
-	cp -a .gitignore $(DESTDIR)
 	cp -a README*.md LICENSE etc $(DESTDIR)
 	cp -a moran* $(DESTDIR)
 	cp -a default.yaml key_bindings.yaml punctuation.yaml symbols.yaml $(DESTDIR)


### PR DESCRIPTION
直接使用主干的 .gitignore 会导致 opencc 等文件缺失。

This reverts commit e4d630690c9d1ef5d94e76aa4008dc4b179d5dc6.