### PR TITLE
Revert "enhance: 手動加載 custom 文件以兼容於 plum 的 patch_files"

### DIFF
--- a/moran.schema.yaml
+++ b/moran.schema.yaml
@@ -468,4 +468,3 @@ __include: moran:/octagram/enable_for_sentence
 # patch:
 #   __include: moran:/octagram/disable
  
-__patch: moran.custom:/patch?

--- a/moran_aux.schema.yaml
+++ b/moran_aux.schema.yaml
@@ -414,5 +414,3 @@ moran:
 
 # 默認啓用語言模型
 __include: moran:/octagram/enable_for_sentence
-
-__patch: moran_aux.custom:/patch?

--- a/moran_fixed.schema.yaml
+++ b/moran_fixed.schema.yaml
@@ -255,5 +255,3 @@ moran:
   #     # 能造出不受碼表的限制的詞，因此適合字詞模式使用
   #     # 例如 輸入tnfb//空格 然後輸入tbnk上屏「頭腦」 fgbk上屏「風暴」，再輸入x//空格，則可以用tnfb上屏「頭腦風暴」
   #     freestyle: false
-
-__patch: moran_fixed.custom:/patch?

--- a/moran_sentence.schema.yaml
+++ b/moran_sentence.schema.yaml
@@ -292,5 +292,3 @@ moran:
 
 # 默認啓用語言模型
 __include: moran:/octagram/enable_for_sentence
-
-__patch: moran_sentence.custom:/patch?


### PR DESCRIPTION
目前的做法会产生一个问题：由于 plum 中的 patch_files 总是追加在文件末尾，最终会覆盖掉用户 *.custom.yaml 中的某些补丁
在下游显式地载入补丁可能是更好的做法
```yaml
patch_files:
  moran.schema.yaml:
    - moran.mkm:/patch
    - moran.custom:/patch?
 ```