### PR TITLE
造句模式4码会出现超过二字的多字词问题

### DIFF
--- a/lua/moran_express_translator.lua
+++ b/lua/moran_express_translator.lua
@@ -124,6 +124,7 @@ function top.init(env)
     -- output 狀態
     env.output_i = 0
     env.output_injected_secondary = {}
+    env.is_sentence_making = false
 end
 
 function top.fini(env)
@@ -131,6 +132,7 @@ function top.fini(env)
     env.smart = nil
     env.rfixed = nil
     env.output_injected_secondary = nil
+    env.is_sentence_making = nil
     collectgarbage()
 end
 
@@ -147,8 +149,8 @@ function top.func(input, seg, env)
     local indicator = env.quick_code_indicator
 
     -- 用戶尚未選過字時，調用碼表。
-    local is_sentence_making = not (env.engine.context.input == input)
-    if not is_sentence_making or env.quick_code_in_sentence_making then
+    env.is_sentence_making = not (env.engine.context.input == input)
+    if not env.is_sentence_making or env.quick_code_in_sentence_making then
         local fixed_res = env.fixed:query(input, seg)
         -- 如果輸入長度爲 4，只輸出 2 字詞。
         if fixed_res ~= nil then
@@ -158,7 +160,7 @@ function top.func(input, seg, env)
                     for cand in fixed_res:iter() do
                         top.output_from_fixed(env, cand)
                     end
-                elseif inflexible and env.inject_fixed_words then
+                elseif inflexible and env.inject_fixed_words and not env.is_sentence_making then
                     -- 固詞 + 長詞 = 只有詞
                     for cand in fixed_res:iter() do
                         if utf8.len(cand.text) > 1 then
@@ -188,11 +190,11 @@ function top.func(input, seg, env)
                 end
             elseif input_len < 4 then          -- 造句模式下，只使用固定單字（詞語無法固定）
                 for cand in fixed_res:iter() do
-                    if not is_sentence_making or utf8.len(cand.text) == 1 then
+                    if not env.is_sentence_making or utf8.len(cand.text) == 1 then
                         top.output_from_fixed(env, cand)
                     end
                 end
-            elseif not is_sentence_making then  -- input_len > 4，輸出所有
+            elseif not env.is_sentence_making then  -- input_len > 4，輸出所有
                 for cand in fixed_res:iter() do
                     top.output_from_fixed(env, cand)
                 end
@@ -343,7 +345,7 @@ function top.output(env, cand)
     -- 注意：需要保證 spelling hint 僅對 3 字以下詞開啓
     yield(cand)
     env.output_i = env.output_i + 1
-    if env.output_i == 1 then
+    if env.output_i == 1 and not env.is_sentence_making then
         -- drain injected cands
         local cands = env.output_injected_secondary
         env.output_injected_secondary = {}

--- a/lua/moran_express_translator.lua
+++ b/lua/moran_express_translator.lua
@@ -1,10 +1,12 @@
 -- Moran Translator (for Express Editor)
--- Copyright (c) 2023, 2024, 2025 ksqsf
+-- Copyright (c) 2023, 2024, 2025, 2026 ksqsf
 --
--- Ver: 0.12.0
+-- Ver: 0.12.1
 --
 -- This file is part of Project Moran
 -- Licensed under GPLv3
+--
+-- 0.12.1: 造詞模式阻止輸出簡碼碼表多字詞
 --
 -- 0.12.0: 引入惰性加載
 --
@@ -153,24 +155,16 @@ function top.func(input, seg, env)
         -- 如果輸入長度爲 4，只輸出 2 字詞。
         if fixed_res ~= nil then
             if (input_len == 4) then
-                if inflexible and env.is_sentence_making then
-                -- 固詞 + 造句模式 ，無視inject_fixed_words 和 inject_fixed_chars
-                for cand in fixed_res:iter() do
-                    local cand_len = utf8.len(cand.text)
-                    if cand_len == 2 then
-                        top.output_word_from_fixed(env, cand)
-                    end
-                end
-                elseif inflexible and env.inject_fixed_words and env.inject_fixed_chars then
+                if inflexible and env.inject_fixed_words and env.inject_fixed_chars then
                     -- 如果固詞, inject_fixed_words 和 inject_fixed_chars 同時打開，則理解爲掛接用法，直接輸出碼表。
                     for cand in fixed_res:iter() do
-                        top.output_from_fixed(env, cand)
+                        top.output_from_fixed(env, cand, is_sentence_making)
                     end
                 elseif inflexible and env.inject_fixed_words then
                     -- 固詞 + 長詞 = 只有詞
                     for cand in fixed_res:iter() do
                         if utf8.len(cand.text) > 1 then
-                            top.output_word_from_fixed(env, cand)
+                            top.output_word_from_fixed(env, cand, is_sentence_making)
                         end
                     end
                 elseif inflexible and env.inject_fixed_chars then
@@ -180,7 +174,7 @@ function top.func(input, seg, env)
                         if cand_len == 1 then
                             top.output_char_from_fixed(env, cand)
                         elseif cand_len == 2 then
-                            top.output_word_from_fixed(env, cand)
+                            top.output_word_from_fixed(env, cand, is_sentence_making)
                         end
                     end
                 elseif inflexible then
@@ -188,7 +182,7 @@ function top.func(input, seg, env)
                     for cand in fixed_res:iter() do
                         local cand_len = utf8.len(cand.text)
                         if cand_len == 2 then
-                            top.output_word_from_fixed(env, cand)
+                            top.output_word_from_fixed(env, cand, is_sentence_making)
                         end
                     end
                 else
@@ -197,12 +191,13 @@ function top.func(input, seg, env)
             elseif input_len < 4 then          -- 造句模式下，只使用固定單字（詞語無法固定）
                 for cand in fixed_res:iter() do
                     if not is_sentence_making or utf8.len(cand.text) == 1 then
-                        top.output_from_fixed(env, cand)
+                        log.error(cand.text)
+                        top.output_from_fixed(env, cand, is_sentence_making)
                     end
                 end
             elseif not is_sentence_making then  -- input_len > 4，輸出所有
                 for cand in fixed_res:iter() do
-                    top.output_from_fixed(env, cand)
+                    top.output_from_fixed(env, cand, is_sentence_making)
                 end
             end
         end
@@ -221,10 +216,10 @@ function top.func(input, seg, env)
     local inject_chars = {}  -- valid only when inject_has_priority
     local inject_words = {}  -- valid only when inject_has_priority
     local num_injections = 0 -- valid only when inject_has_priority
-    if (not fixed_triggered and input_len == 4 and not is_sentence_making) then
+    if (not fixed_triggered and input_len == 4) then
         for cand in moran.query_translation(env.fixed, input, seg, nil) do
             local cand_len = utf8.len(cand.text)
-            if (env.inject_fixed_chars and cand_len == 1) or (env.inject_fixed_words and cand_len > 2) then
+            if (env.inject_fixed_chars and cand_len == 1) or (env.inject_fixed_words and cand_len > 2 and not is_sentence_making) then
                 if cand_len ~= 1 or (cand_len == 1 and not env.quick_code_indicator_skip_chars) then
                     cand:get_genuine().comment = indicator
                 end
@@ -368,16 +363,18 @@ function top.output_char_from_fixed(env, cand)
     top.output(env, cand)
 end
 
-function top.output_word_from_fixed(env, cand)
-    cand.comment = env.quick_code_indicator
-    top.output(env, cand)
+function top.output_word_from_fixed(env, cand, is_sentence_making)
+    if not is_sentence_making or utf8.len(cand.text) == 2 then
+        cand.comment = env.quick_code_indicator
+        top.output(env, cand)
+    end
 end
 
-function top.output_from_fixed(env, cand)
+function top.output_from_fixed(env, cand, is_sentence_making)
     if utf8.len(cand.text) == 1 then
         top.output_char_from_fixed(env, cand)
     else
-        top.output_word_from_fixed(env, cand)
+        top.output_word_from_fixed(env, cand, is_sentence_making)
     end
 end
 

--- a/lua/moran_express_translator.lua
+++ b/lua/moran_express_translator.lua
@@ -124,7 +124,6 @@ function top.init(env)
     -- output 狀態
     env.output_i = 0
     env.output_injected_secondary = {}
-    env.is_sentence_making = false
 end
 
 function top.fini(env)
@@ -132,7 +131,6 @@ function top.fini(env)
     env.smart = nil
     env.rfixed = nil
     env.output_injected_secondary = nil
-    env.is_sentence_making = nil
     collectgarbage()
 end
 
@@ -149,18 +147,26 @@ function top.func(input, seg, env)
     local indicator = env.quick_code_indicator
 
     -- 用戶尚未選過字時，調用碼表。
-    env.is_sentence_making = not (env.engine.context.input == input)
-    if not env.is_sentence_making or env.quick_code_in_sentence_making then
+    local is_sentence_making = not (env.engine.context.input == input)
+    if not is_sentence_making or env.quick_code_in_sentence_making then
         local fixed_res = env.fixed:query(input, seg)
         -- 如果輸入長度爲 4，只輸出 2 字詞。
         if fixed_res ~= nil then
             if (input_len == 4) then
-                if inflexible and env.inject_fixed_words and env.inject_fixed_chars then
+                if inflexible and env.is_sentence_making then
+                -- 固詞 + 造句模式 ，無視inject_fixed_words 和 inject_fixed_chars
+                for cand in fixed_res:iter() do
+                    local cand_len = utf8.len(cand.text)
+                    if cand_len == 2 then
+                        top.output_word_from_fixed(env, cand)
+                    end
+                end
+                elseif inflexible and env.inject_fixed_words and env.inject_fixed_chars then
                     -- 如果固詞, inject_fixed_words 和 inject_fixed_chars 同時打開，則理解爲掛接用法，直接輸出碼表。
                     for cand in fixed_res:iter() do
                         top.output_from_fixed(env, cand)
                     end
-                elseif inflexible and env.inject_fixed_words and not env.is_sentence_making then
+                elseif inflexible and env.inject_fixed_words then
                     -- 固詞 + 長詞 = 只有詞
                     for cand in fixed_res:iter() do
                         if utf8.len(cand.text) > 1 then
@@ -190,11 +196,11 @@ function top.func(input, seg, env)
                 end
             elseif input_len < 4 then          -- 造句模式下，只使用固定單字（詞語無法固定）
                 for cand in fixed_res:iter() do
-                    if not env.is_sentence_making or utf8.len(cand.text) == 1 then
+                    if not is_sentence_making or utf8.len(cand.text) == 1 then
                         top.output_from_fixed(env, cand)
                     end
                 end
-            elseif not env.is_sentence_making then  -- input_len > 4，輸出所有
+            elseif not is_sentence_making then  -- input_len > 4，輸出所有
                 for cand in fixed_res:iter() do
                     top.output_from_fixed(env, cand)
                 end
@@ -215,7 +221,7 @@ function top.func(input, seg, env)
     local inject_chars = {}  -- valid only when inject_has_priority
     local inject_words = {}  -- valid only when inject_has_priority
     local num_injections = 0 -- valid only when inject_has_priority
-    if (not fixed_triggered and input_len == 4) then
+    if (not fixed_triggered and input_len == 4 and not is_sentence_making) then
         for cand in moran.query_translation(env.fixed, input, seg, nil) do
             local cand_len = utf8.len(cand.text)
             if (env.inject_fixed_chars and cand_len == 1) or (env.inject_fixed_words and cand_len > 2) then
@@ -345,7 +351,7 @@ function top.output(env, cand)
     -- 注意：需要保證 spelling hint 僅對 3 字以下詞開啓
     yield(cand)
     env.output_i = env.output_i + 1
-    if env.output_i == 1 and not env.is_sentence_making then
+    if env.output_i == 1 then
         -- drain injected cands
         local cands = env.output_injected_secondary
         env.output_injected_secondary = {}

--- a/lua/moran_express_translator.lua
+++ b/lua/moran_express_translator.lua
@@ -191,7 +191,6 @@ function top.func(input, seg, env)
             elseif input_len < 4 then          -- 造句模式下，只使用固定單字（詞語無法固定）
                 for cand in fixed_res:iter() do
                     if not is_sentence_making or utf8.len(cand.text) == 1 then
-                        log.error(cand.text)
                         top.output_from_fixed(env, cand, is_sentence_making)
                     end
                 end


### PR DESCRIPTION
阻止造句模式下，四码输入返回了超过二字的多字词
<img width="484" height="482" alt="ae5e571fe5271a9e7f0517dc89abfd98" src="https://github.com/user-attachments/assets/dc95e1ed-6ea0-4460-b882-ac5cd5a793af" />
<img width="111" height="209" alt="1)OI5V`NHM0MT4Z_R7UCBSQ" src="https://github.com/user-attachments/assets/07c11e04-1060-4f93-8602-8e83565ad26b" />
