### PR TITLE
ci: run simp_moran test against simp artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        schema: [moran, moran_aux, moran.hint, moran.charset, moran.ijrq]
+        schema: [moran, moran_aux, moran.hint, moran.charset, moran.ijrq, simp_moran]
         lua_version: [5.5, 5.4, 5.3, 5.2, jit]
         librime: [master, 1.13.1]
     steps:
@@ -119,7 +119,7 @@ jobs:
       - name: Download Rime config
         uses: actions/download-artifact@v8
         with:
-          name: "Trad-FullPack"
+          name: ${{ matrix.schema == 'simp_moran' && 'Simp-FullPack' || 'Trad-FullPack' }}
           path: ./dist
       - name: Setup Mira and dependencies
         run: |

--- a/tests/simp_moran.test.yaml
+++ b/tests/simp_moran.test.yaml
@@ -17,7 +17,7 @@ deploy:
       - send: le
         assert: eq(cand[1].text, "乐") and eq(cand[1].comment, "⚡️")
       - send: lem
-        assert: eq(cand[1].text, "楽") and eq(cand[1].comment, "⚡️")
+        assert: eq(cand[1].text, "楽") and eq(cand[1].comment, "")
       - send: lemd
         assert: eq(cand[1].text, "楽") and eq(cand[1].comment, "")
       - send: hello


### PR DESCRIPTION
## Summary

- add `simp_moran` to the existing CI test matrix
- make the test job download `Simp-FullPack` for `simp_moran`, while keeping the other schemas on `Trad-FullPack`
- reuse the already-built simplified artifact instead of building simplified dist again

## Validation

- `git diff --check`