### PR TITLE
Fix variants option list bounds

### DIFF
--- a/lua/moran_processor.lua
+++ b/lua/moran_processor.lua
@@ -318,8 +318,11 @@ return {
                     and variants:get_at(1):get_value():get_string():match("^std_")
                 then
                     env.variants = {}
-                    for j = 0, variants.size do
-                        table.insert(env.variants, variants:get_at(j):get_value():get_string())
+                    for j = 0, variants.size - 1 do
+                        local variant = variants:get_at(j)
+                        if variant and variant.type == "kScalar" then
+                            table.insert(env.variants, variant:get_value():get_string())
+                        end
                     end
                     break
                 end


### PR DESCRIPTION
## Summary

- fix the variants option list loop to stop at `variants.size - 1`
- guard each collected item before reading it as a scalar value

## Motivation

`ConfigList:get_at()` is zero-based, while `size` is the number of elements. The previous loop used `0, variants.size`, which reads one item past the end and can make `variants:get_at(j)` nil, causing startup errors like:

```text
moran_processor.lua:365: attempt to index a nil value
```

## Validation

- `git diff --check`
- inspected the target Lua change; `luac` is not available in this environment
