### PR TITLE
fix: update simplified table entries

### DIFF
--- a/moran.words.dict.yaml
+++ b/moran.words.dict.yaml
@@ -9400,6 +9400,7 @@ PV師	5	PV ui;vb
 令人驚異
 切墩
 切配
+款号	1
 
 # Mini Lyre Dict
 # https://github.com/rimeinn/Lyre/commit/c020d23d334aec77a59b1d5a5b3bcc8c07c86bd0

--- a/moran_fixed.dict.yaml
+++ b/moran_fixed.dict.yaml
@@ -13629,6 +13629,7 @@ C盤	cpj
 甸	dmgt
 典故	dmgu
 電櫃	dmgv
+大漠孤煙直	dmgv
 電掛	dmgw
 大漠孤煙	dmgy
 點	dmh
@@ -20860,6 +20861,7 @@ F盤	fpj
 發現一個問題	fxyt
 風險意識	fxyu
 風行一時	fxyu
+分析一下	fxyx
 分析原因	fxyy
 放心早餐	fxzc
 風險自擔	fxzd
@@ -23463,7 +23465,6 @@ F盤	fpj
 皋	gkb
 稿本	gkbf
 感慨悲歌	gkbg
-公開曝光	gkbg
 公開曝光	gkbg
 告白	gkbl
 告便	gkbm
@@ -34084,8 +34085,8 @@ H盤	hpj
 出乎我的意料	ihwl
 常務	ihwu
 瑒	ihwy
-常委	ihwz
 腸胃	ihwz
+常委	ihwz
 悵	ihx
 嘗	ihx
 暢銷	ihxc
@@ -35352,8 +35353,8 @@ H盤	hpj
 衝破樊籬	ipfl
 春肥	ipfz
 春光	ipgd
-產品規格	ipgg
 春耕	ipgg
+產品規格	ipgg
 純鋼	ipgh
 脣膏	ipgk
 春灌	ipgr
@@ -36733,6 +36734,7 @@ I盤	ipj
 赤心報國	ixbg
 癡心不悔	ixbh
 重新編輯	ixbj
+重新部署	ixbu
 程序編寫	ixbx
 垂涎不已	ixby
 長線操作	ixcz
@@ -54025,7 +54027,6 @@ JK制服	jkvf
 米醋	micu
 謀朝篡位	micw
 泌	mid
-泌	midb
 濔	mide
 渳	mide
 灖	midf
@@ -55718,7 +55719,6 @@ JK制服	jkvf
 貌若潘安	mrpa
 默認皮膚	mrpf
 美人胚子	mrpz
-默認情況下	mrq
 每日簽到	mrqd
 盲人騎瞎馬	mrqm
 默認情況下	mrqx
@@ -60004,6 +60004,7 @@ JK制服	jkvf
 櫱	nxm
 闑	nxmn
 槷	nxmv
+蘖	nxmx
 臲	nxn
 那些哪次	nxnc
 難兄難弟	nxnd
@@ -66281,7 +66282,6 @@ P站	pvj
 芊芊玉手	qqyu
 請求援助	qqyv
 輕輕一躍	qqyy
-千千音樂	qqyy
 遒	qqz
 求全責備	qqzb
 龜茲	qqzi
@@ -72007,6 +72007,7 @@ P站	pvj
 三江五湖	sjwh
 三萬	sjwj
 叄萬	sjwj
+時間問題	sjwt
 三維	sjwz
 三圍	sjwz
 三相	sjxd
@@ -79435,7 +79436,6 @@ T恤衫	txuj
 收銀	ubyn
 手印	ubyn
 受孕	ubyp
-鼠標引擎	ubyq
 受援	ubyr
 受用	ubys
 恕不遠送	ubys
@@ -83432,6 +83432,7 @@ U盤	upj
 食肉動物	urdw
 視若等閒	urdx
 上任鵝城	urei
+輸入法	urf
 輸入方案	urfa
 深入腹地	urfd
 殺人放火	urfh
@@ -85272,7 +85273,6 @@ U盤	upj
 勝友如雲	uyry
 失業人員	uyry
 縗	uys
-啥意思	uys
 是藥三分毒	uysd
 摔死	uysi
 食用色素	uyss
@@ -94462,6 +94462,7 @@ WiFi	wifi
 誤人子弟	wrzd
 爲人作嫁	wrzj
 爲人作嫁衣	wrzy
+無人在意	wrzy
 爲啥	ws
 無所不包	wsbb
 萬死不辭	wsbc
@@ -94854,6 +94855,7 @@ WiFi	wifi
 務	wum
 無碼	wuma
 誤碼	wuma
+無謀	wumb
 武廟	wumc
 屋門	wumf
 柮	wumi
@@ -103805,6 +103807,7 @@ WiFi	wifi
 眼耳鼻喉	yebh
 夜班	yebj
 業報	yebk
+嬰兒般的睡眠	yebm
 一兒半女	yebn
 豔而不俗	yebs
 也不	yebu
@@ -104693,7 +104696,6 @@ WiFi	wifi
 銀行卡號	yhkh
 優化空間	yhkj
 有何困難	yhkn
-藝畫開天	yhkt
 有話快說	yhku
 沿海開放城市	yhku
 友好鄰邦	yhlb
@@ -106679,7 +106681,6 @@ WiFi	wifi
 醫療糾紛	yljf
 醫療機構	yljg
 一兩句話	yljh
-一力降十會	yljh
 因陋就簡	yljj
 月亮姐姐	yljj
 有利局面	yljm
@@ -110458,6 +110459,7 @@ WiFi	wifi
 依稀可見	yxkj
 優先考慮	yxkl
 有些困難	yxkn
+以下克上	yxku
 有些可惜	yxkx
 遊戲科學	yxkx
 也許可以	yxky
@@ -115784,8 +115786,8 @@ WiFi	wifi
 成爲	igwk
 稱爲	igwk
 稱謂	igwk
-常委	ihwk
 腸胃	ihwk
+常委	ihwk
 鴟尾	iiwk
 潮位	ikwk
 春闈	ipwk
@@ -116768,7 +116770,6 @@ WiFi	wifi
 不怕死	bps
 爆破筒	bpt
 白皮書	bpu
-不排除	bpv
 不便宜	bpy
 爆破組	bpz
 表情包	bqb
@@ -116882,6 +116883,7 @@ WiFi	wifi
 博士後	buh
 不識貨	buh
 辦事處	bui
+必勝客	buk
 不少了	bul
 不說了	bul
 半衰期	buq
@@ -117208,6 +117210,7 @@ CD機	cdj
 催一催	cyc
 猜一猜	cyc
 湊一湊	cyc
+撮一撮	cyc
 參與度	cyd
 策源地	cyd
 曾有過	cyg
@@ -117219,7 +117222,6 @@ CD機	cdj
 催一下	cyx
 餐飲業	cyy
 菜園子	cyz
-撮一撮	cyz
 操作符	czf
 存在感	czg
 操縱桿	czg
@@ -117462,6 +117464,7 @@ CD機	cdj
 獨幕劇	dmj
 都沒了	dml
 達美樂	dml
+躲貓貓	dmm
 獨木橋	dmq
 大忙人	dmr
 多媒體	dmt
@@ -117602,7 +117605,6 @@ CD機	cdj
 大衆化	dvh
 打招呼	dvh
 地中海	dvh
-彈指間	dvj
 打折扣	dvk
 呆住了	dvl
 電渣爐	dvl
@@ -117745,7 +117747,6 @@ CD機	cdj
 地藏王	dzw
 電子學	dzx
 打字員	dzy
-大動作	dzz
 刀子嘴	dzz
 二把刀	ebd
 餓不餓	ebe
@@ -117810,6 +117811,7 @@ Excel	eks
 二年級	enj
 耳旁風	epf
 阿房宮	epg
+惡趣味	eqw
 二人臺	ert
 二人轉	erv
 耳塞機	esj
@@ -117964,6 +117966,7 @@ Excel	eks
 房產證	fiv
 房產主	fiv
 副產物	fiw
+放長線	fix
 翻車魚	fiy
 方程組	fiz
 飛機場	fji
@@ -118058,6 +118061,7 @@ Excel	eks
 父親節	fqj
 放棄了	fql
 飛起來	fql
+發情期	fqq
 發起人	fqr
 番茄鍾	fqv
 番茄汁	fqv
@@ -118071,7 +118075,6 @@ Excel	eks
 發熱量	frl
 瘋人院	fry
 非人哉	frz
-發生的	fsd
 分散度	fsd
 複色光	fsg
 風俗畫	fsh
@@ -118090,7 +118093,7 @@ Excel	eks
 反貪局	ftj
 反推力	ftl
 芬太尼	ftn
-佛跳牆	ftp
+佛跳牆	ftq
 繁體字	ftz
 發帖子	ftz
 發生的	fud
@@ -118126,7 +118129,6 @@ Excel	eks
 腐殖質	fvv
 附着物	fvw
 輔助性	fvx
-放長線	fvx
 分之一	fvy
 非專業	fvy
 非正義	fvy
@@ -119097,6 +119099,7 @@ git	git
 沉積物	ijw
 觸控板	ikb
 出口額	ike
+長寬高	ikg
 喘口氣	ikq
 創可貼	ikt
 出口商	iku
@@ -120462,6 +120465,7 @@ Keynote	knt
 馬來亞	mly
 仫佬族	mlz
 沒明白	mmb
+沒毛病	mmb
 沒門兒	mme
 毛毛蟲	mmi
 明明就	mmj
@@ -120870,7 +120874,6 @@ Keynote	knt
 娘娘腔	nnq
 農奴制	nnv
 努努嘴	nnz
-尼泊爾	npe
 年平均	npj
 拿破崙	npl
 牛脾氣	npq
@@ -120906,6 +120909,7 @@ Keynote	knt
 你特麼	ntm
 你他喵	ntm
 那天起	ntq
+牛頭人	ntr
 女同志	ntv
 男同志	ntv
 泥腿子	ntz
@@ -121072,6 +121076,7 @@ PDF	pdf
 破紀錄	pjl
 瓶頸期	pjq
 判決書	pju
+撲克牌	pkp
 貧困線	pkx
 疲勞感	plg
 破爛貨	plh
@@ -121364,7 +121369,6 @@ PVP	pvp
 情人節	qrj
 去死吧	qsb
 去送吧	qsb
-請稍等	qsd
 遣散費	qsf
 窮死了	qsl
 氣死了	qsl
@@ -122166,6 +122170,7 @@ SD卡	sdk
 同質化	tvh
 太直接	tvj
 天主教	tvj
+彈指間	tvj
 偷着樂	tvl
 通脹率	tvl
 通知欄	tvl
@@ -122500,7 +122505,6 @@ SD卡	sdk
 申請書	uqu
 雙曲線	uqx
 殺人案	ura
-輸入法	urf
 說人話	urh
 雙人牀	uri
 雙刃劍	urj
@@ -123615,6 +123619,7 @@ Word	wrd
 興沖沖	xii
 宣傳片	xip
 吸塵器	xiq
+小程序	xix
 性價比	xjb
 現階段	xjd
 心勁兒	xje
@@ -123649,7 +123654,6 @@ Word	wrd
 新紀元	xjy
 喜加一	xjy
 小舅子	xjz
-小可愛	xka
 小可愛	xka
 想開點	xkd
 許可法	xkf
@@ -124444,7 +124448,6 @@ Word	wrd
 坐地板	zdb
 子弟兵	zdb
 最低層	zdc
-知道的	zdd
 自動擋	zdd
 最低點	zdd
 早點兒	zde
@@ -124460,7 +124463,6 @@ Word	wrd
 自動門	zdm
 坐地鐵	zdt
 早稻田	zdt
-這倒是	zdu
 子弟書	zdu
 坐得正	zdv
 總噸位	zdw

--- a/moran_fixed_simp.dict.yaml
+++ b/moran_fixed_simp.dict.yaml
@@ -7257,6 +7257,7 @@ B盘	bpj
 毕业院校	byyx
 兵营	byyy
 别有用意	byyy
+迸	byz
 禀奏	byzb
 不预则废	byzf
 必要组成部分	byzf
@@ -13225,6 +13226,7 @@ C语言	cyy
 甸	dmgt
 典故	dmgu
 电柜	dmgv
+大漠孤烟直	dmgv
 电挂	dmgw
 大漠孤烟	dmgy
 扂	dmh
@@ -20226,6 +20228,7 @@ F盘	fpj
 发现一个问题	fxyt
 风险意识	fxyu
 风行一时	fxyu
+分析一下	fxyx
 分析原因	fxyy
 放心早餐	fxzc
 风险自担	fxzd
@@ -22908,7 +22911,6 @@ F盘	fpj
 杲	gkom
 睾	gkp
 高票	gkpc
-公开曝光	gkpg
 公开曝光	gkpg
 羔皮	gkpi
 高攀	gkpj
@@ -33098,8 +33100,8 @@ H盘	hpj
 出乎我的意料	ihwl
 常务	ihwu
 玚	ihwy
-常委	ihwz
 肠胃	ihwz
+常委	ihwz
 尝	ihx
 畅销	ihxc
 畅想	ihxd
@@ -33721,7 +33723,7 @@ H盘	hpj
 谄	ijyx
 襜	ijyy
 躔	ijz
-掺杂	ijzao
+掺杂	ijza
 串家走户	ijzh
 产自	ijzi
 筹集资金	ijzj
@@ -34308,8 +34310,8 @@ IP地址	ipdv
 冲破樊篱	ipfl
 春肥	ipfz
 春光	ipgd
-产品规格	ipgg
 春耕	ipgg
+产品规格	ipgg
 纯钢	ipgh
 唇膏	ipgk
 春灌	ipgr
@@ -35660,6 +35662,7 @@ I盘	ipj
 赤心报国	ixbg
 痴心不悔	ixbh
 重新编辑	ixbj
+重新部署	ixbu
 程序编写	ixbx
 垂涎不已	ixby
 长线操作	ixcz
@@ -52450,8 +52453,7 @@ JK制服	jkvf
 迷彩	micl
 米醋	micu
 谋朝篡位	micw
-米	mid
-泌	midb
+泌	mid
 迷瞪	midg
 面朝大海	midh
 谜底	midi
@@ -54096,7 +54098,6 @@ JK制服	jkvf
 貌若潘安	mrpa
 默认皮肤	mrpf
 美人胚子	mrpz
-默认情况下	mrq
 每日签到	mrqd
 盲人骑瞎马	mrqm
 默认情况下	mrqx
@@ -58289,6 +58290,7 @@ JK制服	jkvf
 内心空虚	nxkx
 蘖	nxm
 糵	nxmx
+蘖	nxmx
 那些哪次	nxnc
 难兄难弟	nxnd
 捏弄	nxns
@@ -64405,7 +64407,6 @@ P站	pvj
 芊芊玉手	qqyu
 请求援助	qqyv
 轻轻一跃	qqyy
-千千音乐	qqyy
 遒	qqz
 求全责备	qqzb
 龟兹	qqzi
@@ -69996,6 +69997,7 @@ P站	pvj
 三江五湖	sjwh
 三万	sjwj
 叁万	sjwj
+时间问题	sjwt
 三维	sjwz
 三围	sjwz
 三相	sjxd
@@ -77221,7 +77223,6 @@ T恤衫	txuj
 收银	ubyn
 手印	ubyn
 受孕	ubyp
-鼠标引擎	ubyq
 受援	ubyr
 受用	ubys
 恕不远送	ubys
@@ -82977,7 +82978,6 @@ U盘	upj
 胜友如云	uyry
 失业人员	uyry
 实用	uys
-啥意思	uys
 是药三分毒	uysd
 摔死	uysi
 食用色素	uyss
@@ -91922,6 +91922,7 @@ U盘	upj
 误人子弟	wrzd
 为人作嫁	wrzj
 为人作嫁衣	wrzy
+无人在意	wrzy
 为啥	ws
 无所不包	wsbb
 万死不辞	wsbc
@@ -92310,6 +92311,7 @@ U盘	upj
 梧	wum
 无码	wuma
 误码	wuma
+无谋	wumb
 武庙	wumc
 屋门	wumf
 舞迷	wumi
@@ -100925,6 +100927,7 @@ U盘	upj
 眼耳鼻喉	yebh
 夜班	yebj
 业报	yebk
+婴儿般的睡眠	yebm
 一儿半女	yebn
 艳而不俗	yebs
 也不	yebu
@@ -101808,7 +101811,6 @@ U盘	upj
 银行卡号	yhkh
 优化空间	yhkj
 有何困难	yhkn
-艺画开天	yhkt
 有话快说	yhku
 沿海开放城市	yhku
 咉	yhky
@@ -103665,7 +103667,6 @@ U盘	upj
 医疗纠纷	yljf
 医疗机构	yljg
 一两句话	yljh
-一力降十会	yljh
 因陋就简	yljj
 月亮姐姐	yljj
 有利局面	yljm
@@ -105445,7 +105446,6 @@ U盘	upj
 用功	ysgs
 雅俗共赏	ysgu
 有所感悟	ysgw
-有时候	ysh
 严丝合缝	yshf
 永恒	yshg
 勇悍	yshj
@@ -107332,6 +107332,7 @@ U盘	upj
 依稀可见	yxkj
 优先考虑	yxkl
 有些困难	yxkn
+以下克上	yxku
 有些可惜	yxkx
 游戏科学	yxkx
 也许可以	yxky
@@ -112462,8 +112463,8 @@ U盘	upj
 成为	igwk
 称为	igwk
 称谓	igwk
-常委	ihwk
 肠胃	ihwk
+常委	ihwk
 鸱尾	iiwk
 潮位	ikwk
 春闱	ipwk
@@ -113387,7 +113388,6 @@ U盘	upj
 不怕死	bps
 爆破筒	bpt
 白皮书	bpu
-不排除	bpv
 不便宜	bpy
 爆破组	bpz
 表情包	bqb
@@ -113501,6 +113501,7 @@ U盘	upj
 博士后	buh
 不识货	buh
 办事处	bui
+必胜客	buk
 不说了	bul
 不少了	bul
 半衰期	buq
@@ -113824,6 +113825,7 @@ CD机	cdj
 催一催	cyc
 猜一猜	cyc
 凑一凑	cyc
+撮一撮	cyc
 参与度	cyd
 策源地	cyd
 曾有过	cyg
@@ -113835,7 +113837,6 @@ CD机	cdj
 催一下	cyx
 餐饮业	cyy
 菜园子	cyz
-撮一撮	cyz
 操作符	czf
 存在感	czg
 操纵杆	czg
@@ -114077,6 +114078,7 @@ CD机	cdj
 独幕剧	dmj
 都没了	dml
 达美乐	dml
+躲猫猫	dmm
 独木桥	dmq
 大忙人	dmr
 多媒体	dmt
@@ -114220,7 +114222,6 @@ CD机	cdj
 打招呼	dvh
 地中海	dvh
 大众化	dvh
-弹指间	dvj
 打折扣	dvk
 电渣炉	dvl
 呆住了	dvl
@@ -114364,7 +114365,6 @@ CD机	cdj
 地藏王	dzw
 电子学	dzx
 打字员	dzy
-大动作	dzz
 刀子嘴	dzz
 二把刀	ebd
 饿不饿	ebe
@@ -114429,6 +114429,7 @@ Excel	eks
 二年级	enj
 耳旁风	epf
 阿房宫	epg
+恶趣味	eqw
 二人台	ert
 二人转	erv
 耳塞机	esj
@@ -114583,6 +114584,7 @@ Excel	eks
 房产证	fiv
 房产主	fiv
 副产物	fiw
+放长线	fix
 翻车鱼	fiy
 方程组	fiz
 飞机场	fji
@@ -114677,6 +114679,7 @@ Excel	eks
 父亲节	fqj
 放弃了	fql
 飞起来	fql
+发情期	fqq
 发起人	fqr
 番茄钟	fqv
 番茄汁	fqv
@@ -114690,7 +114693,6 @@ Excel	eks
 发热量	frl
 疯人院	fry
 非人哉	frz
-发生的	fsd
 分散度	fsd
 复色光	fsg
 风俗画	fsh
@@ -114708,7 +114710,7 @@ Excel	eks
 反贪局	ftj
 反推力	ftl
 芬太尼	ftn
-佛跳墙	ftp
+佛跳墙	ftq
 繁体字	ftz
 发帖子	ftz
 发生的	fud
@@ -114744,7 +114746,6 @@ Excel	eks
 腐殖质	fvv
 附着物	fvw
 辅助性	fvx
-放长线	fvx
 分之一	fvy
 非专业	fvy
 非正义	fvy
@@ -114879,6 +114880,7 @@ Excel	eks
 鬼地方	gdf
 高低杠	gdg
 挂电话	gdh
+干得好	gdh
 干电池	gdi
 供电局	gdj
 搞定了	gdl
@@ -114928,7 +114930,6 @@ Excel	eks
 高个子	ggz
 高回报	ghb
 共和党	ghd
-干得好	ghd
 过会儿	ghe
 鬼画符	ghf
 共和国	ghg
@@ -115717,6 +115718,7 @@ git	git
 沉积物	ijw
 触控板	ikb
 出口额	ike
+长宽高	ikg
 喘口气	ikq
 创可贴	ikt
 出口商	iku
@@ -117082,6 +117084,7 @@ Keynote	knt
 马来亚	mly
 仫佬族	mlz
 没明白	mmb
+没毛病	mmb
 没门儿	mme
 毛毛虫	mmi
 明明就	mmj
@@ -117490,7 +117493,6 @@ Keynote	knt
 娘娘腔	nnq
 农奴制	nnv
 努努嘴	nnz
-尼泊尔	npe
 年平均	npj
 拿破仑	npl
 牛脾气	npq
@@ -117527,6 +117529,7 @@ Keynote	knt
 你特么	ntm
 你他喵	ntm
 那天起	ntq
+牛头人	ntr
 女同志	ntv
 男同志	ntv
 泥腿子	ntz
@@ -117696,6 +117699,7 @@ PDF	pdf
 破纪录	pjl
 瓶颈期	pjq
 判决书	pju
+扑克牌	pkp
 贫困线	pkx
 破烂儿	ple
 疲劳感	plg
@@ -117986,7 +117990,6 @@ PVP	pvp
 情人节	qrj
 去死吧	qsb
 去送吧	qsb
-请稍等	qsd
 遣散费	qsf
 气死了	qsl
 穷死了	qsl
@@ -118784,6 +118787,7 @@ SD卡	sdk
 同质化	tvd
 天主教	tvj
 太直接	tvj
+弹指间	tvj
 通胀率	tvl
 偷着乐	tvl
 通知栏	tvl
@@ -119118,7 +119122,6 @@ SD卡	sdk
 神枪手	uqu
 双曲线	uqx
 杀人案	ura
-输入法	urf
 说人话	urh
 双人床	uri
 双刃剑	urj
@@ -120236,6 +120239,7 @@ Word	wrd
 兴冲冲	xii
 宣传片	xip
 吸尘器	xiq
+小程序	xix
 性价比	xjb
 现阶段	xjd
 心劲儿	xje
@@ -120270,7 +120274,6 @@ Word	wrd
 新纪元	xjy
 喜加一	xjy
 小舅子	xjz
-小可爱	xka
 小可爱	xka
 想开点	xkd
 许可法	xkf
@@ -121067,7 +121070,6 @@ Word	wrd
 最低层	zdc
 自动挡	zdd
 最低点	zdd
-知道的	zdd
 早点儿	zde
 最低分	zdf
 自动化	zdh
@@ -121082,7 +121084,6 @@ Word	wrd
 坐地铁	zdt
 早稻田	zdt
 子弟书	zdu
-这倒是	zdu
 坐得正	zdv
 总吨位	zdw
 总担心	zdx

--- a/tools/data/moran_chai.txt
+++ b/tools/data/moran_chai.txt
@@ -9040,7 +9040,7 @@
 呥	kr	口冉	
 呦	ky	口幼	
 呧	kd	口氐	
-周	kj	口几	
+周	kt	口土
 周	kk	冂口	
 呩	ku	口示	
 呪	kx	口兄	
@@ -11931,7 +11931,7 @@
 巇	ug	山戈	
 巇	ux	山戲	
 巈	uj	山鞠	
-巉	ui	石毚	
+巉	ui	山毚
 巉	ut	山兔	
 巊	uy	山嬰	
 巋	ug	山歸	
@@ -17829,8 +17829,8 @@
 瀸	dx	氵韱	
 瀹	dc	氵冊	
 瀹	dy	氵龠	
-瀺	dt	氵兔	
 瀺	di	氵毚	
+瀺	dt	氵兔
 瀻	dd	氵戴	
 瀼	dx	氵襄	
 瀽	dj	氵蹇	
@@ -68827,7 +68827,7 @@
 𨪱	jv	金正	auto
 𨪱	vj	正金	auto
 𨪲	jt	金田	auto
-𨪳	jd	金大	auto
+𨪳	jh	金火	auto
 𨪴	jo	金日	auto
 𨪵	jj	金句	auto
 𨪶	jy	金晏	auto
@@ -92322,6 +92322,7 @@
 𰧨	um	石木	auto
 𰧩	uh	石赫	auto
 𰧪	ub	石貝	auto
+𰧫	ui	石毚	auto
 𰧫	ut	石兔	auto
 𰧭	uu	示士	auto
 𰧮	uq	示丌	auto


### PR DESCRIPTION
## Summary
- reapply the checked safe fixes from #226 onto current `main`
- keep `dmgy` for `大漠孤烟` and add `dmgv` for `大漠孤烟直`
- remove `千千音乐` instead of replacing it with QQ 音乐
- add `款号` to `moran.words.dict.yaml` after the header block

## Validation
- `/root/.local/bin/uv run tools/check_simp_table.py`
  - passes; existing warnings: `乾纲独断`, `情深深雨濛濛`
- `git diff --check main...HEAD`
- confirmed no `千千音乐` / `QQ音乐` remains in changed target files

Fixes #226