### PR TITLE
Fix 螣 pronunciation codes

### DIFF
--- a/moran_fixed_simp.dict.yaml
+++ b/moran_fixed_simp.dict.yaml
@@ -72410,7 +72410,6 @@ P站	pvj
 特卖	teml
 特命	temy
 特	ten
-螣	teo
 特批	tepi
 特派	tepl
 特聘	tepn


### PR DESCRIPTION
## Summary
- change 螣 pronunciation in dictionary entries from `te` to `tg`
- remove the remaining simplified fixed `teo` entry so 螣 only keeps `tg` fixed codes
- remove the `te` source pronunciation for 螣 from `tools/data/chars.txt`

## Validation
- installed `uv` locally and Python 3.12 via uv
- installed Debian `opencc` for `opencc_dict`
- ran `make all` successfully
- checked all root `*.dict.yaml` entries containing 螣; no remaining 螣 entry uses `te` in code fields
- ran `git diff --check`