### PR TITLE
Add lightweight Python linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,6 +142,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
+      - name: 檢查 Python 工具格式與 import 順序
+        run: make lint-python
       - name: 檢查簡體碼表是否有繁體字
         run: uv run tools/check_simp_table.py
       - name: 檢查詞庫裏是否混入了多空格

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@
 - **moran_aux** options: https://zrmfans.cn/book/schemas/fushai/features.md
 - **moran_sentence** is a cut-down version of moran, see the yaml file and compare to moran.schema.yaml
 
+## Commit message conventions
+
+- Follow the repository's existing commit style. Prefer short imperative subjects with a lowercase prefix such as `dict:`, `dict(chai):`, `fix:`, `fix(lua):`, `ci:`, `docs:`, `feat:` when applicable.
+- Do not use generic Title Case subjects like `Update ...`, `Add ...`, `Fix ...` unless that casing/pattern already matches nearby history for the same kind of change. Match local history first.
+- Pick the narrowest accurate prefix for the files changed. For example: CI/workflow changes should usually use `ci:`, documentation-only changes `docs:`, dictionary updates `dict:` or `dict(...)`, and user-visible bug fixes `fix:` or `fix(...)`.
+- Before committing, inspect recent history with `git log --oneline origin/main -n 20` and mirror the dominant style.
+
 ## Change workflow
 
 - Prefer minimal source-data edits. For dictionary entries with generated auxiliary-code comments, edit the spelling/code or word form before generated auxiliary data; do not hand-edit generated auxiliary-code fields unless the repository documentation says that field is source data.

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ quick: chars zrmdb chaifen opencc zrlf
 dict: update-compact-dicts
 all: quick dict
 
+lint-python:
+	uv run --with ruff ruff check tools
+
 ############
 # 單字信息 #
 ############
@@ -97,4 +100,4 @@ test: dist
 	mira -C /tmp/mira-cache tests/moran_aux.test.yaml
 	rm -rf /tmp/mira-cache
 
-.PHONY: quick all dict chars zrlf zrmdb chaifen update-compact-dicts sync-essay dazhu opencc mdict dist test
+.PHONY: quick all dict chars zrlf zrmdb chaifen update-compact-dicts sync-essay dazhu opencc mdict dist test lint-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,13 @@ license = {text = "GPLv3"}
 
 [tool.pdm]
 distribution = false
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+extend-exclude = [
+    "dist",
+]
+
+[tool.ruff.lint]
+select = ["E9", "F401", "F541", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "requests",
     "mdict_utils",
 ]
-requires-python = "==3.12.*"
+requires-python = ">=3.12,<3.15"
 readme = "README.md"
 license = {text = "GPLv3"}
 

--- a/tools/check_simp_table.py
+++ b/tools/check_simp_table.py
@@ -1,6 +1,6 @@
-import opencc
 import re
-import os
+
+import opencc
 
 cc = opencc.OpenCC('t2s.json')
 RE_ENTRY = re.compile(r'^([^\t]+)\t')

--- a/tools/dazhu.py
+++ b/tools/dazhu.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 import argparse
-import opencc
 import os
-from collections import defaultdict
 import re
 import sys
+from collections import defaultdict
+
+import opencc
 
 
 class FakeOpenCC:

--- a/tools/flypyify.py
+++ b/tools/flypyify.py
@@ -70,6 +70,7 @@ def 韻母轉換(pinyin: str) -> str:
 
 ################################################################################
 from collections import defaultdict
+
 可接i介音聲母 = {'b','p','m','f','d','t','n','l','j','q','x','y'}
 反向映射表 = defaultdict(list)
 

--- a/tools/gen_chars.py
+++ b/tools/gen_chars.py
@@ -1,7 +1,8 @@
 # gen_chars.py -- 生成單字表
 
-from utils import *
 import argparse
+
+from utils import *
 from zrmify import zrmify
 
 parser = argparse.ArgumentParser()

--- a/tools/gen_mdx.py
+++ b/tools/gen_mdx.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
+import sys
+
 from mdict_utils.base.writemdict import MDictWriter
 from utils import *
 from zrmify import zrmify
-import sys
-import os
-
 
 if len(sys.argv) != 2:
     print('Usage: gen_mdx.py <output path>')

--- a/tools/gen_zrlf.py
+++ b/tools/gen_zrlf.py
@@ -1,7 +1,8 @@
 # gen_zrlf.py -- 生成兩分詞庫
 
-from utils import *
 import argparse
+
+from utils import *
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--simplified', action='store_true')

--- a/tools/llm_tradify.py
+++ b/tools/llm_tradify.py
@@ -4,12 +4,13 @@
 注意，LLM 輸出爲臺標，最後需用 opencc 轉爲 opencc 標。
 """
 
-import requests
-import json
-import sys
-import os
-import time
 import argparse
+import os
+import sys
+import time
+
+import requests
+
 
 def read_input_file(filename):
     """Read the input file and return list of (word, pinyin) tuples"""
@@ -165,7 +166,7 @@ def main():
         sys.exit(1)
     
     print(f"Processing {len(words)} words in batches of {args.batch_size}...")
-    print(f"Each batch will be saved as separate .in and .out files")
+    print("Each batch will be saved as separate .in and .out files")
     
     # Process in batches
     successful_batches = process_in_batches(words, api_key, args.input_file, args.batch_size)

--- a/tools/rime_dict.py
+++ b/tools/rime_dict.py
@@ -1,8 +1,11 @@
-from collections import defaultdict
 import re
-import requests
+from collections import defaultdict
+
 import pandas as pd
+import requests
+
 from opencc import OpenCC
+
 
 def read_compact_dict(filename):
     RE_COMPACT_DICT_LINE = re.compile(r"^(.+)\t([ ;a-z]+)\t(\d*)$")

--- a/tools/schemagen.py
+++ b/tools/schemagen.py
@@ -9,20 +9,18 @@
 # 序的使用者所有.)
 #
 
-import sys
 import argparse
 import traceback
 from collections import *
 from itertools import *
-import zrmify
-import flypyify
-import math
-import opencc
-from pypinyin import lazy_pinyin
 from operator import *
-import re
-import regex
 
+import flypyify
+import regex
+import zrmify
+from pypinyin import lazy_pinyin
+
+import opencc
 
 double_pinyin_choices = ['zrm', 'flypy']
 auxiliary_code_choices = ['zrm', 'user']

--- a/tools/sync_essay.py
+++ b/tools/sync_essay.py
@@ -3,11 +3,10 @@
 # 本項目詞庫自提交至 rime/rime-essay 後，承衆高手校對糾錯。本腳本自動
 # 從 rime-essay 拉取修改到項目詞庫中。
 
-import requests
-import opencc
 import pandas as pd
 from rime_dict import base_dict, latest_essay
 
+import opencc
 
 CC = opencc.OpenCC('t2s.json')
 def normalize(s):

--- a/tools/sync_moe.py
+++ b/tools/sync_moe.py
@@ -8,11 +8,13 @@ sync_moe.py -- 同步上游萌百詞條
 4. 調用 gen-dict 將其轉換成
 """
 
-import requests
-from collections import defaultdict
-import opencc
 import re
+from collections import defaultdict
+
+import requests
 from utils import *
+
+import opencc
 
 t2s = opencc.OpenCC('t2s.json')
 s2t = opencc.OpenCC('s2t.json')
@@ -158,4 +160,4 @@ def count_tokens(text: str) -> int:
 
 with open('out_ambi.txt', 'w') as f:
     f.write(str_ambi(ambi))
-print(f'歧義詞語已寫入 out_ambi.txt')
+print('歧義詞語已寫入 out_ambi.txt')

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,7 +1,7 @@
-from collections import defaultdict, OrderedDict
 import os
+from collections import OrderedDict, defaultdict
 from datetime import datetime
-from typing import Generator, Iterable, Tuple, Iterator, overload
+from typing import Iterable, Iterator, Tuple, overload
 
 
 def tsv_reader(path: str) -> Iterator[list[str]]:

--- a/tools/zrmify.py
+++ b/tools/zrmify.py
@@ -75,6 +75,7 @@ def 韻母轉換(pinyin: str) -> str:
 
 ################################################################################
 from collections import defaultdict
+
 可接i介音聲母 = {'b','p','m','f','d','t','n','l','j','q','x','y'}
 反向映射表 = defaultdict(list)
 
@@ -129,8 +130,8 @@ ALL_PINYIN = ["a", "ai", "an", "ang", "ao", "ba", "bai", "ban", "bang", "bao", "
 
 ALL_ZRMSP = [zrmify1(py) for py in ALL_PINYIN]
 
-import string
 import itertools
+import string
 
 ALL_NON_SP = sorted(list(set(a+b for (a,b) in itertools.product(string.ascii_lowercase, string.ascii_lowercase)) - set(ALL_ZRMSP)))
 


### PR DESCRIPTION
## Summary
- add a lightweight Ruff config for the Python tools
- add `make lint-python`
- run Python linting in CI `dict-qa`
- auto-fix import order, unused imports, and trivial f-string issues in `tools/`

## Validation
- `ruff check tools`
- `python -m compileall -q tools`
- `git diff --check`

## Notes
- keep this PR intentionally narrow
- only enable low-risk checks for now: import sorting, unused imports, and a couple of obviously safe error classes
- avoid broader style rewrites or star-import cleanup in this PR
