### PR TITLE
feat(lua): 輔篩模式支持簡碼提示

### DIFF
--- a/lua/moran_hint_filter.lua
+++ b/lua/moran_hint_filter.lua
@@ -1,10 +1,12 @@
 -- Moran Translator (for Express Editor)
 -- Copyright (c) 2023-2026 ksqsf
 --
--- Ver: 0.4.1
+-- Ver: 0.5.0
 --
 -- This file is part of Project Moran
 -- Licensed under GPLv3
+--
+-- 0.5.0: 輔篩模式支持簡碼提示。
 --
 -- 0.4.1: 修復 aux_table 格式未適配問題。
 --
@@ -31,9 +33,16 @@ function Module.init(env)
     end
 
     env.is_auxfilter = env.name_space == "auxfilter"
-    env.enable_quick_code_hint = env.engine.schema.config:get_bool("moran/enable_quick_code_hint")
-    -- 輔篩模式禁止簡碼提示
-    if env.enable_quick_code_hint and not env.is_auxfilter then
+    env.enable_quick_code_hint = env.engine.schema.config:get_bool("moran/enable_quick_code_hint") or false
+    env.quick_code_hint_max_length = nil
+    if env.is_auxfilter then
+        -- 輔篩的簡碼來源就是掛接碼表，因而只在掛接開啓時提示，
+        -- 並與掛接使用同一碼長限制。
+        env.enable_quick_code_hint = env.enable_quick_code_hint
+            and (env.engine.schema.config:get_bool("moran/fix/use_dict") or false)
+        env.quick_code_hint_max_length = env.engine.schema.config:get_int("moran/fix/use_dict_max_length") or 3
+    end
+    if env.enable_quick_code_hint then
         -- The user might have changed it.
         local dict = env.engine.schema.config:get_string("fixed/dictionary")
         env.quick_code_hint_reverse = ReverseLookup(dict)
@@ -56,6 +65,7 @@ function Module.fini(env)
     env.aux_table = nil
     env.enable_quick_code_hint = nil
     env.quick_code_hint_reverse = nil
+    env.quick_code_hint_max_length = nil
     collectgarbage()
 end
 
@@ -112,7 +122,13 @@ function Module.get_quickcode_hint(env, cand, gcand)
     local in_use = false
     local codes = {}
     for code in all_codes:gmatch("%S+") do
-        if #code < 4 or (env.inject_fixed_words and len >= 3) then
+        local code_is_hintable
+        if env.quick_code_hint_max_length then
+            code_is_hintable = #code <= env.quick_code_hint_max_length
+        else
+            code_is_hintable = #code < 4 or (env.inject_fixed_words and len >= 3)
+        end
+        if code_is_hintable then
             if code == cand.preedit:gsub("%s", "") then
                 in_use = true
             else

--- a/moran_aux.schema.yaml
+++ b/moran_aux.schema.yaml
@@ -379,6 +379,15 @@ moran:
   # 該功能不顯示拆分，建議使用 Ctrl+i 顯示單字拆分
   enable_aux_hint: false
 
+  # 簡快碼提示（包括字和詞）
+  # 僅在 moran/fix/use_dict 開啓時生效，且只提示長度不超過
+  # moran/fix/use_dict_max_length 的編碼。
+  enable_quick_code_hint: false
+  # 默認值 null 表示使用 quick_code_indicator，可按需設爲其他提示符或 ""。
+  quick_code_hint_indicator: null
+  # 取消單字的簡快碼提示
+  quick_code_hint_skip_chars: false
+
   # 「置頂」功能相關設置
   # 輸入時通過快捷鍵 Ctrl+t 可以將高亮顯示的候選置頂，被置頂的候選位置固定，不再參與調頻
   # 對同一輸入碼最高支持8個置頂詞，當嘗試置頂第9個詞時，最早被置頂的詞將會失效

--- a/tests/moran_aux.test.yaml
+++ b/tests/moran_aux.test.yaml
@@ -28,6 +28,31 @@ deploy:
       - send: 'keyima'
         assert: eq(cand[1].text, '可以嗎')
 
+  quick_code_hint_without_fix_dict:
+    patch:
+      moran/enable_quick_code_hint: true
+    tests:
+      - send: 'yyteer'
+        assert: cand[1].text == '英特爾' and eq(cand[1].comment, '')
+
+  quick_code_hint_with_fix_dict:
+    patch:
+      moran/enable_quick_code_hint: true
+      moran/fix/use_dict: true
+      moran/fix/use_dict_max_length: 3
+    tests:
+      - send: 'yyteer'
+        assert: cand[1].text == '英特爾' and eq(cand[1].comment, '⚡yte')
+
+  quick_code_hint_respects_fix_dict_max_length:
+    patch:
+      moran/enable_quick_code_hint: true
+      moran/fix/use_dict: true
+      moran/fix/use_dict_max_length: 2
+    tests:
+      - send: 'yyteer'
+        assert: cand[1].text == '英特爾' and eq(cand[1].comment, '')
+
   tab:
     tests:
       - send: 'lmjx{Tab}j{space}{space}'


### PR DESCRIPTION
## 改动

- 允许辅筛模式使用简快码提示
- 仅在 `moran/fix/use_dict` 开启时启用提示
- 仅输出长度不超过 `moran/fix/use_dict_max_length` 的编码
- 在 `moran_aux.schema.yaml` 补充相关配置说明
- 增加未挂接、码长不足、正常提示三组行为测试

## 验证

- `mira -C /work/moran-aux-quickcode-hint/cache-final tests/moran_aux.test.yaml`
- `mira -C /work/moran-aux-quickcode-hint/cache-hint-final tests/moran.hint.test.yaml`
- 使用本地构建的 `rime_api_console`（librime 1.13.1 + 系统 librime-lua）验证：
  - `use_dict: false`：不提示
  - `use_dict_max_length: 2`：不提示 `yte`
  - `use_dict_max_length: 3`：显示 `英特尔 ⚡yte`