### PR TITLE
fix(lua): 非第二用字標準支持切換回首個用字標準

### DIFF
--- a/lua/moran_processor.lua
+++ b/lua/moran_processor.lua
@@ -283,6 +283,12 @@ local function variant_toggle_processor(key_event, env)
         -- 默認安裝中，首選項是 zh_t 或 zh_s（無 opencc），故選擇第二選項。
         ctx:set_option(v2, true)
         ctx:set_option(v1, false)
+    elseif not ctx:get_option(v1) and not ctx:get_option(v2) then
+        -- 其他用字標準被激活時，切換到第一個
+        for _, v in ipairs(env.variants) do
+            ctx:set_option(v, false)
+        end
+        ctx:set_option(v1, true)
     end
 
     return kAccepted

--- a/tests/moran.test.yaml
+++ b/tests/moran.test.yaml
@@ -77,6 +77,17 @@ deploy:
       - send: 'w{Control+s}{Control+s}{Control+s}2'
         assert: eq(commit, '为')
 
+  std_switcher_third_active:
+    patch:
+      switches/@4/+:
+        options: [std_t2tw, std_t2s, std_t2hk]
+        states: [台, 简, 港]
+    options:
+      std_t2hk: true
+    tests:
+      - send: 'w{Control+s}2'
+        assert: eq(commit, '爲')
+
   emoji:
     options:
       emoji: true


### PR DESCRIPTION
### 問題

`variant_toggle_processor` (Ctrl+S) 只處理了 `env.variants` 的前兩個選項。
當方案配置了 3 個以上用字標準，
切到第 3 個後按Ctrl+S 不會有任何反應，無法切回第一個。
- `get_option(v1)` → false，`get_option(v2)` → false，前兩個分支不進
- `moran.all(env.variants, ...)` → 因 v3/v4 為 true 返回 false，第三個分支也不進

### 修復

```lua
elseif not ctx:get_option(v1) and not ctx:get_option(v2) then
    for _, v in ipairs(env.variants) do
        ctx:set_option(v, false)
    end
    ctx:set_option(v1, true)
end
```