### PR TITLE
dict: 補充繁體碼表中的猪字簡碼 vuq

### DIFF
--- a/moran_fixed.dict.yaml
+++ b/moran_fixed.dict.yaml
@@ -90262,6 +90262,7 @@ U盤	upj
 豬排	vupl
 主頻	vupn
 主僕	vupu
+猪	vuq
 竹橋	vuqc
 舟山羣島	vuqd
 中沙羣島	vuqd


### PR DESCRIPTION
## 變更
- 在繁體碼表 `moran_fixed.dict.yaml` 加入 `猪\tvuq`，字形為「猪」（U+732A）。
- 插入位置在 `vupu` 與 `vuqc` 之間，保持編碼順序。
- 保留原有 `豬 / vuuv`；簡體碼表已有 `猪 / vuq`，無需修改。

## 驗證
- 靜態斷言通過：僅新增一行、條目唯一、相鄰編碼有序、原有「豬」保留、簡體對應條目存在。
- `git diff --check` 通過。
- 嘗試 `make all` 和 `make dist`，均因環境缺少 `uv` 失敗；未能生成 dist，因此未執行 mira 行為測試。
